### PR TITLE
fix vertical spacing on thin displays

### DIFF
--- a/bounties/css/style.css
+++ b/bounties/css/style.css
@@ -722,6 +722,7 @@ body {
     border-width: 1px;
     border-radius: 1px;
     padding: .75em 1.5em;
+    display: inline-block;
 }
 
 .social_icons{

--- a/bounties/index.html
+++ b/bounties/index.html
@@ -48,7 +48,7 @@
 					<hr id="hr">
 					<br>
 					<br>
-					<div style="margin-bottom:em;" class="col-lg-6">
+					<div style="margin-bottom:1em;" class="col-lg-6">
 						<h3>Portable Solidity Debugger</h3>
 						<p>2,000 REP</p>
 						<a class="full_details_button" id="bounty_two" onCLick="bounty_two()">FULL DETAILS</a>


### PR DESCRIPTION
On thinner displays, the layout clashes on the bounties page.

Before:
![image](https://user-images.githubusercontent.com/549323/36522352-13225d52-176a-11e8-9322-e6fa48201695.png)

After:
![image](https://user-images.githubusercontent.com/549323/36522360-260a035c-176a-11e8-9af7-aa12edd63df0.png)
